### PR TITLE
rebuild unreadable persisted durables on connect

### DIFF
--- a/transports/nats_persisted_consumer.go
+++ b/transports/nats_persisted_consumer.go
@@ -56,6 +56,24 @@ func (c *natsPersistedConsumer) connect(ctx context.Context, stream jetstream.St
 	if err != nil {
 		return fmt.Errorf("create persisted consumer shard %d: %w", c.shard, err)
 	}
+	// A durable that survived a server file-store corruption can come back
+	// half-dead: CreateOrUpdateConsumer still returns it, but the server can
+	// neither serve its info nor deliver from it, and a subscription on it
+	// blocks forever without erroring. Probe the info and rebuild the durable
+	// when it is unreadable. The stream keeps every unacked message
+	// (work-queue retention), so the fresh consumer resumes delivery from the
+	// pending state.
+	if _, infoErr := jsConsumer.Info(ctx); infoErr != nil {
+		c.queue.logger.Error("persisted consumer shard unreadable; rebuilding",
+			"shard", c.shard, "durable", consumerCfg.Durable, "error", infoErr)
+		if delErr := stream.DeleteConsumer(ctx, consumerCfg.Durable); delErr != nil {
+			return fmt.Errorf("delete unreadable persisted consumer shard %d: %w", c.shard, delErr)
+		}
+		jsConsumer, err = stream.CreateOrUpdateConsumer(ctx, consumerCfg)
+		if err != nil {
+			return fmt.Errorf("recreate persisted consumer shard %d: %w", c.shard, err)
+		}
+	}
 	mctx, err := jsConsumer.Messages(jetstream.PullHeartbeat(persistedPullHeartbeat))
 	if err != nil {
 		return fmt.Errorf("start persisted messages context shard %d: %w", c.shard, err)

--- a/transports/nats_persisted_rebuild_test.go
+++ b/transports/nats_persisted_rebuild_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) RealTyme SA. All rights reserved.
+
+package transports
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/matryer/is"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// stubMessagesContext satisfies jetstream.MessagesContext; connect only
+// stores it, so no methods are exercised.
+type stubMessagesContext struct{ jetstream.MessagesContext }
+
+// stubConsumer is a jetstream.Consumer whose Info can be forced to fail,
+// mimicking a durable that survived a file-store corruption half-dead.
+type stubConsumer struct {
+	jetstream.Consumer
+	infoErr error
+}
+
+func (s stubConsumer) Info(context.Context) (*jetstream.ConsumerInfo, error) {
+	if s.infoErr != nil {
+		return nil, s.infoErr
+	}
+	return &jetstream.ConsumerInfo{}, nil
+}
+
+func (s stubConsumer) Messages(...jetstream.PullMessagesOpt) (jetstream.MessagesContext, error) {
+	return stubMessagesContext{}, nil
+}
+
+// rebuildStream records consumer creates and deletes; when brokenFirst is
+// set, the first created consumer reports an unreadable info.
+type rebuildStream struct {
+	jetstream.Stream
+	brokenFirst bool
+	creates     int
+	deleted     []string
+}
+
+func (s *rebuildStream) CreateOrUpdateConsumer(_ context.Context, _ jetstream.ConsumerConfig) (jetstream.Consumer, error) {
+	s.creates++
+	if s.brokenFirst && s.creates == 1 {
+		return stubConsumer{infoErr: errors.New("error opening msg block file")}, nil
+	}
+	return stubConsumer{}, nil
+}
+
+func (s *rebuildStream) DeleteConsumer(_ context.Context, consumer string) error {
+	s.deleted = append(s.deleted, consumer)
+	return nil
+}
+
+func newRebuildTestQueue() *natsPersistedQueue {
+	return &natsPersistedQueue{
+		streamName: "test_queue",
+		shards:     1,
+		logger:     hclog.NewNullLogger(),
+	}
+}
+
+// connect must detect a durable whose info is unreadable, delete it and
+// recreate it instead of subscribing to a consumer that will never deliver.
+func TestConnectRebuildsUnreadableConsumer(t *testing.T) {
+	asrt := is.New(t)
+
+	q := newRebuildTestQueue()
+	c := &natsPersistedConsumer{queue: q}
+	stream := &rebuildStream{brokenFirst: true}
+
+	asrt.NoErr(c.connect(context.Background(), stream))
+	asrt.Equal(stream.creates, 2)
+	asrt.Equal(stream.deleted, []string{q.shardDurable(0)})
+}
+
+// connect must leave a healthy durable untouched.
+func TestConnectKeepsReadableConsumer(t *testing.T) {
+	asrt := is.New(t)
+
+	q := newRebuildTestQueue()
+	c := &natsPersistedConsumer{queue: q}
+	stream := &rebuildStream{}
+
+	asrt.NoErr(c.connect(context.Background(), stream))
+	asrt.Equal(stream.creates, 1)
+	asrt.Equal(len(stream.deleted), 0)
+}


### PR DESCRIPTION
A durable consumer that survived a server file-store corruption can come back half-dead: CreateOrUpdateConsumer still returns it, but the server can neither serve its info nor deliver from it, and the pull subscription blocks forever without erroring — stalling every persisted-FIFO write until the consumer is deleted by hand. Probe the consumer info on connect and delete + recreate the durable when it is unreadable. The work-queue stream keeps every unacked message, so the fresh consumer resumes from the pending state.